### PR TITLE
Legit build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 2.8)
+project("pimpmypcbnewsvg")
+set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
+
+set(CMAKE_CXX_STANDARD 11)
+find_package(TinyXML2)
+
+
+include_directories(${TINYXML2_INCLUDE_DIR})
+add_definitions(-D__CMAKE__)
+add_executable(pimpmypcbnewsvg pimpmypcbnewsvg.cpp)
+target_link_libraries(pimpmypcbnewsvg ${TINYXML2_LIBRARIES})
+install(TARGETS pimpmypcbnewsvg DESTINATION ${CMAKE_SOURCE_DIR})

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # pimpmypcbnewsvg
-simple SVG merger for KiCad/pcbnew
+Simple SVG merger for KiCad/pcbnew
 
-want to print your PCB layout on paper but the colors are nasty?
-what if you could have most layers almost white, while the F.SilkS or F.Fab layer black?
+Want to print your PCB layout on paper but the colors are nasty?
+What if you could have most layers almost white, while the F.SilkS or F.Fab layer black?
 
-this tool can help
-first, in pcbnew:
+This tool can help
+First, in pcbnew:
 - export your PCB layout as SVG
 - in the export options choose "one file per layer" and "black and white"
 - it might be a good idea to create and use a subfolder /svg/ to not polute your project main folder
@@ -13,20 +13,29 @@ pcbnew will generate files for each layer, with the layer name appended to the f
 - pass any one of them (e.g. "/home/user/somewhere/myLEDblinker/svg/myLEDblinker-F.Cu.svg") as commandline argument to the tool (or drag and drop over it (this works on windows)) and the tool will figure out the basename "/home/user/somewhere/myLEDblinker/svg/myLEDblinker-" and try to load the svg files of the other layers too
 the colors will be changed, and the layers will be aranged in a specific order, configurable from the pimpmypcbnewsvg.xml file, and the merged result will be saved into the same folder
 
-this sort of works with pcbnew from the stable kicad version right now (4.0.something)
-the pcb layers graphics in the exported SVGs are not as accurate as the gerbers!
+This sort of works with pcbnew from the stable kicad version right now (4.0.something)
+The pcb layers graphics in the exported SVGs are not as accurate as the gerbers!
 
 --------
 
-pimpmypcbnewsvg requires tinyxml2 and a C++11 compiler, i think it should build easily on linux, windows, etc..
-pimpmypcbnewsvg comes with a Code::Blocks project with a linux build target (so far)
-tinyxml2 must be placed in the project folder under its own folder /tinyxml2/
+pimpmypcbnewsvg has the following dependencies: tinyxml2, cmake, and a  C++11 capable compiler (recent versions of clang, gcc, etc.).
 
-the executable looks for "pimpmypcbnewsvg.xml" which is used as a configuration file
-it should contain information about two things:
+To build, perform:
+
+```bash
+mkdir build
+cd build
+cmake ..
+make install
+```
+
+The pimpmypcbnewsvg executable will installed into the root of the source directory, where you can run it via `./pimpmypcbnewsvg`.
+
+The executable looks for "pimpmypcbnewsvg.xml" which is used as a configuration file
+It should contain information about two things:
 - what are the exact names of the layers (so that it can substitute them in the file names) and their default colors
 - one or more "output file" setups, each describing the output file suffix (including the svg extension) which layers it should contain, in what order and with what colors
 
 ---------
 
-it seems pcbnew "kind of" exports the drill holes inside the copper layer SVG files as white color (while the copper itself is black) so pimpmypcbnewsvg has the functionality to try and extract it sepparately as a virtual layer
+It seems pcbnew "kind of" exports the drill holes inside the copper layer SVG files as white color (while the copper itself is black) so pimpmypcbnewsvg has the functionality to try and extract it sepparately as a virtual layer

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ First, in pcbnew:
 - in the export options choose "one file per layer" and "black and white"
 - it might be a good idea to create and use a subfolder /svg/ to not polute your project main folder
 pcbnew will generate files for each layer, with the layer name appended to the filename
-- pass any one of them (e.g. "/home/user/somewhere/myLEDblinker/svg/myLEDblinker-F.Cu.svg") as commandline argument to the tool (or drag and drop over it (this works on windows)) and the tool will figure out the basename "/home/user/somewhere/myLEDblinker/svg/myLEDblinker-" and try to load the svg files of the other layers too
+- pass any one of them (e.g. `/home/user/somewhere/myLEDblinker/svg/myLEDblinker-F.Cu.svg`) as commandline argument to the tool (or drag and drop over it (this works on windows)) and the tool will figure out the basename `/home/user/somewhere/myLEDblinker/svg/myLEDblinker-` and try to load the svg files of the other layers too
 the colors will be changed, and the layers will be aranged in a specific order, configurable from the pimpmypcbnewsvg.xml file, and the merged result will be saved into the same folder
 
 This sort of works with pcbnew from the stable kicad version right now (4.0.something)
@@ -18,7 +18,11 @@ The pcb layers graphics in the exported SVGs are not as accurate as the gerbers!
 
 --------
 
-pimpmypcbnewsvg has the following dependencies: tinyxml2, cmake, and a  C++11 capable compiler (recent versions of clang, gcc, etc.).
+pimpmypcbnewsvg has the following dependencies: 
+
+- tinyxml2
+- cmake
+- C++11 capable compiler (recent versions of clang, gcc)
 
 To build, perform:
 
@@ -31,7 +35,7 @@ make install
 
 The pimpmypcbnewsvg executable will installed into the root of the source directory, where you can run it via `./pimpmypcbnewsvg`.
 
-The executable looks for "pimpmypcbnewsvg.xml" which is used as a configuration file
+The executable looks for `pimpmypcbnewsvg.xml` which is used as a configuration file
 It should contain information about two things:
 - what are the exact names of the layers (so that it can substitute them in the file names) and their default colors
 - one or more "output file" setups, each describing the output file suffix (including the svg extension) which layers it should contain, in what order and with what colors

--- a/cmake/FindTinyXML2.cmake
+++ b/cmake/FindTinyXML2.cmake
@@ -1,0 +1,15 @@
+# Copyright (c) 2014 Andrew Kelley
+# This file is MIT licensed.
+# See http://opensource.org/licenses/MIT
+
+# TINYXML2_FOUND
+# TINYXML2_INCLUDE_DIR
+# TINYXML2_LIBRARIES
+
+find_path(TINYXML2_INCLUDE_DIR NAMES tinyxml2.h)
+find_library(TINYXML2_LIBRARIES NAMES tinyxml2)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(TINYXML2 DEFAULT_MSG TINYXML2_LIBRARIES TINYXML2_INCLUDE_DIR)
+
+mark_as_advanced(TINYXML2_INCLUDE_DIR TINYXML2_LIBRARIES)

--- a/pimpmypcbnewsvg.cpp
+++ b/pimpmypcbnewsvg.cpp
@@ -4,7 +4,11 @@
 #include <vector>
 #include <unordered_map>
 
+#ifdef __CMAKE__
+#include <tinyxml2.h>
+#else
 #include "tinyxml2/tinyxml2.h"
+#endif
 
 using namespace tinyxml2;
 using std::cout;


### PR DESCRIPTION
This adds a full cmake build system to the project that should 'just work' even as you make changes to your project and you can continue to use Code::blocks for development.  Cmake is nice because it just figures stuff out, so the project now automagically builds on all platforms, and the user can simply have tinyxml2 installed normally without having to put it in a special location.  Cmake will find it where ever it happens to be hiding.  

I also updated the readme with cmake instructions, occasional usage of the shift key, and some markdown prettification stuff.  Just to make it more readable (in my opinion at least).